### PR TITLE
Move documentation to a central hub and detailed spoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,40 +7,6 @@ A collection of tools that support automation of VMWare VCloud Director
 A tool that takes a YAML configuration file describing a vDC, and provisions
 the vApps and VMs contained within.
 
-
-Usage:
-
-    bundle exec bin/vcloud-provision {config_file}
-
-Example configuration files can be located in:
-
-    spec/data/*.yaml
-
-Supports:
-
-* Configuration of multiple vApps/VMs with:
-  * multiple NICs
-  * custom CPU and memory size
-  * multiple additional disks
-  * custom VM metadata
-* Basic idempotent operation - already configured vApps are skipped.
-    
-Limitations:
-
-* Source vApp Template must contain a single VM. This is the recommended 'simple' 
-  method of vApp creation. Complex multi-VM vApps are not supported.
-* Org vDC Networks must be precreated.
-* IP addresses are assigned manually (recommended) or via DHCP. VM IP pools are
-  not supported.
-* Only a single source vApp template is possible at the moment. This requires
-  VMware Tools installed.
-* Configuration file currently does not support sensible defaults for vApps/VMs, making the configuration very verbose and repetitive. This will be fixed in the next release.
-* The configuration currently describes a single vDC. This is expected to change to describe a complete Org.
-
-
-
-
-
 ## [Vcloud Walker][vcloudwalker]
 A tool that reports on the current state of an environment
 
@@ -58,7 +24,5 @@ For more details see: http://fog.io/about/getting_started.html#debugging.
 [vcloudwalker]: https://github.com/alphagov/vcloud-walker
 [edgegateway]: docs/edgegateway.md
 [tag_search]: docs/tag_search.md
-
-
-
+[vcloud-provision]: docs/vcloud-provision.md
 

--- a/docs/vcloud-provision.md
+++ b/docs/vcloud-provision.md
@@ -1,0 +1,33 @@
+#Provision VApps and VMS
+
+Usage:
+
+    bundle exec bin/vcloud-provision {config_file}
+
+Example configuration files can be located in:
+
+    spec/data/*.yaml
+
+Supports:
+
+* Configuration of multiple vApps/VMs with:
+  * multiple NICs
+  * custom CPU and memory size
+  * multiple additional disks
+  * custom VM metadata
+* Basic idempotent operation - already configured vApps are skipped.
+
+Limitations:
+
+* Source vApp Template must contain a single VM. This is the recommended 'simple'
+  method of vApp creation. Complex multi-VM vApps are not supported.
+* Org vDC Networks must be precreated.
+* IP addresses are assigned manually (recommended) or via DHCP. VM IP pools are
+  not supported.
+* Only a single source vApp template is possible at the moment. This requires
+  VMware Tools installed.
+* Configuration file currently does not support sensible defaults for vApps/VMs,
+  making the configuration very verbose and repetitive. This will be fixed in the
+  next release.
+* The configuration currently describes a single vDC. This is expected to change
+  to describe a complete Org.


### PR DESCRIPTION
- vcloud provision documentation moved to file, with link to it in main read me, to match other sections
- also fixed link

/cc @mikepea 
