### PR TITLE
Fix coercing of opts to string in help output

### DIFF
--- a/bin/vcloud-query
+++ b/bin/vcloud-query
@@ -39,7 +39,7 @@ def parse_args
     end
 
     opts.on_tail("-h", "--help", "Show usage instructions") do
-      Kernel.abort opts
+      Kernel.abort opts.to_s
     end
   end
 


### PR DESCRIPTION
Without this change:

```
$ bundle exec bin/vcloud-query -h
    bin/vcloud-query:42:in `abort': can't convert OptionParser into String (TypeError)
    from bin/vcloud-query:42:in `block (2 levels) in parse_args'
    from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/optparse.rb:1391:in `call'
    from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/optparse.rb:1391:in `block in parse_in_order'
    from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/optparse.rb:1347:in `catch'
    from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/optparse.rb:1347:in `parse_in_order'
    from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/optparse.rb:1341:in `order!'
    from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/optparse.rb:1432:in `permute!'
    from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/optparse.rb:1453:in `parse!'
    from bin/vcloud-query:47:in `parse_args'
    from bin/vcloud-query:59:in `<main>'
```

With this change I get the expected help output.
