### PR TITLE
Always minify preamble script.

### DIFF
--- a/lib/vcloud/vm.rb
+++ b/lib/vcloud/vm.rb
@@ -121,11 +121,12 @@ module Vcloud
     def generate_preamble(script_path, vars)
       vapp_name = vapp.name
       script = ERB.new(File.read(script_path), nil, '>-').result(binding)
-      # vCloud can only handle preamble scripts < 2048 bytes
-      if script.bytesize >= 2048 
-        script = Open3.capture2(minifier_tool_location, stdin_data: script).first
-      end
-      script
+      # Preamble scripts can be up to 8192 bytes but must be < ~2048 bytes to
+      # avoid decoding errors during guest customization under Linux (and maybe
+      # others).
+      # TODO: ensure the preamble script is actually a shell script and/or
+      #       that the guest is running Linux.
+      Open3.capture2(minifier_tool_location, stdin_data: script).first
     end
 
     def virtual_hardware_section


### PR DESCRIPTION
We don't know the exact size at which things break, so don't try to be
smart about it.

Thinking about it, this whole approach isn't appropriate to a generic
tool and is going to break horribly for (e.g.) Windows VMs where the
preamble is unlikely to be a bash script. We should probably remove it
completely and leave it up to the caller to Do The Right Thing.
