### PR TITLE
[#60265776] Add vApp/VM power on functionality

### DIFF
--- a/bin/vcloud-launch
+++ b/bin/vcloud-launch
@@ -17,8 +17,9 @@ class App
   end
 
 
-  on("--[no-]verbose", "Verbose output")
-  on("--[no-]debug",   "Debugging output")
+  on("--verbose", "Verbose output")
+  on("--debug",   "Debugging output")
+  on("--no_power_on",  "Do not power on vApps (default is to power on)")
 
   arg :org_config_file
 

--- a/features/vcloud-launch.feature
+++ b/features/vcloud-launch.feature
@@ -10,5 +10,8 @@ Feature: "vcloud-launch" works as a useful command-line tool
     And the banner should document that this app takes options
     And the following options should be documented:
       |--version|
+      |--verbose|
+      |--debug|
+      |--no_power_on|
     And the banner should document that this app's arguments are:
       |org_config_file|

--- a/lib/vcloud/fog_interface.rb
+++ b/lib/vcloud/fog_interface.rb
@@ -101,6 +101,7 @@ module Vcloud
     end
 
     def power_on_vapp vapp_id
+      Vcloud.logger.info("Powering on vApp #{vapp_id}")
       task = vcloud.post_power_on_vapp(vapp_id).body
       vcloud.process_task(task)
     end

--- a/lib/vcloud/launch.rb
+++ b/lib/vcloud/launch.rb
@@ -12,12 +12,16 @@ module Vcloud
       fog_interface = Vcloud::FogInterface.new
       deprecation_handler :run_needs_config_file if config_file.nil?
 
+      puts "cli_options:" if @cli_options[:debug]
+      pp @cli_options if @cli_options[:debug]
+
       config = load_config(config_file)
 
       config[:vapps].each do |vapp_config|
         Vcloud.logger.info("Configuring vApp #{vapp_config[:name]}.")
         vapp = Vapp.new(fog_interface)
         vapp.provision(vapp_config)
+        vapp.power_on unless @cli_options[:no_power_on]
       end
     end
 

--- a/lib/vcloud/vapp.rb
+++ b/lib/vcloud/vapp.rb
@@ -1,10 +1,21 @@
 module Vcloud
   class Vapp
 
-    attr_reader :vdc, :id, :name
+    attr_reader :vdc, :name
 
-    def initialize vcloud
+    def initialize vcloud, config = {}
       @fog_interface = vcloud
+      @name = config[:name]
+      @vdc_name = config[:vdc_name]
+    end
+
+    def id
+      return nil unless @vdc_name
+      return nil unless @name
+      return @id unless @id.nil?
+      @vdc = @fog_interface.vdc_object_by_name @vdc_name
+      model_vapp = @fog_interface.get_vapp_by_vdc_and_name(@vdc, @name)
+      @id = model_vapp ? model_vapp.id : nil
     end
 
     def provision config
@@ -13,15 +24,14 @@ module Vcloud
 
       begin
 
-        @vdc = @fog_interface.vdc_object_by_name @vdc_name
         template = Vcloud::Template.new(@fog_interface, config)
         template_id = template.id
 
         network_names = config[:vm][:network_connections].collect { |h| h[:name] }
         networks = @fog_interface.find_networks(network_names, @vdc_name)
 
-        if model_vapp = @fog_interface.get_vapp_by_vdc_and_name(@vdc, @name)
-          vapp = @fog_interface.get_vapp(model_vapp.id)
+        if id
+          vapp = @fog_interface.get_vapp(id)
           Vcloud.logger.info("Found existing vApp #{vapp[:name]} in vDC '#{vdc.name}'. Skipping.")
         else
           Vcloud.logger.info("Instantiating new vApp #{@name} in vDC '#{vdc.name}'")
@@ -44,7 +54,16 @@ module Vcloud
       vapp
     end
 
-    def running? vapp
+    def power_on
+      raise "Cannot power on a missing vApp." unless id
+      return true if running?
+      @fog_interface.power_on_vapp(id)
+      running?
+    end
+
+    def running?
+      raise "Cannot call running? on a missing vApp." unless id
+      vapp = @fog_interface.get_vapp(id)
       vapp[:status].to_i == 4 ? true : false
     end
 

--- a/lib/vcloud/version.rb
+++ b/lib/vcloud/version.rb
@@ -1,3 +1,3 @@
 module Vcloud
-  VERSION = '0.1.2'
+  VERSION = '0.2.0'
 end

--- a/spec/vcloud/vapp_spec.rb
+++ b/spec/vcloud/vapp_spec.rb
@@ -28,6 +28,40 @@ module Vcloud
       @mock_fog_interface.stub(:post_instantiate_vapp_template).and_return(@mock_fog_request_vapp)
     end
 
+    describe '#power_on' do
+      context "powering on a vapp" do
+
+        config = {
+          :name     => 'test-vapp-1',
+          :vdc_name => 'Test vDC 1',
+        }
+
+        it "should power on a vapp that is not powered on" do
+          vapp = Vcloud::Vapp.new @mock_fog_interface, config
+          @mock_fog_interface.stub(:get_vapp_by_vdc_and_name).and_return(@mock_model_vapp)
+          @mock_fog_interface.should_receive(:power_on_vapp).with(vapp.id)
+          state = vapp.power_on
+          expect(state) == true
+        end
+
+        it "should not power on a vapp that is already powered on, but should return true" do
+          vapp = Vcloud::Vapp.new @mock_fog_interface, config
+          @mock_fog_interface.stub(:get_vapp_by_vdc_and_name).and_return(@mock_model_vapp)
+          @mock_fog_interface.stub(:get_vapp).and_return({:status => 4})
+          @mock_fog_interface.should_not_receive(:power_on_vapp)
+          state = vapp.power_on
+          expect(state) == true
+        end
+
+        it "should raise an error if vapp does not exist" do
+          vapp = Vcloud::Vapp.new @mock_fog_interface, config
+          @mock_fog_interface.stub(:get_vapp_by_vdc_and_name).and_return(nil)
+          expect { vapp.power_on }.to raise_exception(RuntimeError, 'Cannot power on a missing vApp.')
+        end
+
+      end
+    end
+
     describe '#provision' do
       context "provisioning a vapp" do
         config = {


### PR DESCRIPTION
- originally in launch.rb, missed from new code (hence BUG)
- added --no_power_on option, otherwise powers on
- refactor in Vapp class to handle getting id without provision step
