### PR TITLE
fixing encapsulation for vm model

### DIFF
--- a/lib/vcloud/fog_service_interface.rb
+++ b/lib/vcloud/fog_service_interface.rb
@@ -162,10 +162,8 @@ module Vcloud
         task = @vcloud.put_guest_customization_section_vapp(vm_id, customization_req).body
         @vcloud.process_task(task)
       rescue
-        Vcloud.logger.info("=== vars:")
-        Vcloud.logger.info(bootstrap_config[:vars].inspect)
         Vcloud.logger.info("=== interpolated preamble:")
-        Vcloud.logger.info(interpolated_preamble)
+        Vcloud.logger.info(script)
         raise
       end
     end

--- a/lib/vcloud/vapp.rb
+++ b/lib/vcloud/vapp.rb
@@ -49,7 +49,7 @@ module Vcloud
             name,
             InstantiationParams: build_network_config(networks)
           )
-          vm = Vcloud::Vm.new(fog_interface, vms.first, self)
+          vm = Vcloud::Vm.new(vms.first, self)
           vm.customize(config[:vm])
           @vcloud_attributes = fog_interface.get_vapp(id)
         end

--- a/lib/vcloud/vm.rb
+++ b/lib/vcloud/vm.rb
@@ -1,13 +1,12 @@
 module Vcloud
-  class Vm
+  class Vm < Entity
 
-    attr_reader :vm, :vapp, :id
+    attr_reader :vcloud_attributes
 
-    def initialize(fog_interface, vm, vapp)
-      @vm = vm
-      @fog_interface = fog_interface
+    def initialize(vcloud_attributes, vapp)
+      @vcloud_attributes = vcloud_attributes
+      @fog_interface = FogServiceInterface.new
       @vapp = vapp
-      @id = vm[:href].split('/').last
     end
 
     def customize(vm_config)
@@ -59,10 +58,10 @@ module Vcloud
     end
 
     def add_extra_disks(extra_disks)
-      vm = FogModelInterface.new.get_vm_by_href(@vm[:href])
+      vm = FogModelInterface.new.get_vm_by_href(@vcloud_attributes[:href])
       if extra_disks
         extra_disks.each do |extra_disk|
-          Vcloud.logger.info("adding a disk of size #{extra_disk[:size]}MB into VM #{vm.id}")
+          Vcloud.logger.info("adding a disk of size #{extra_disk[:size]}MB into VM #{id}")
           vm.disks.create(extra_disk[:size])
         end
       end
@@ -95,11 +94,11 @@ module Vcloud
             bootstrap_config[:vars]
         )
       end
-      @fog_interface.put_guest_customization_section(@id, name, interpolated_preamble)
+      @fog_interface.put_guest_customization_section(id, name, interpolated_preamble)
     end
 
     def generate_preamble(script_path, vars)
-      vapp_name = vapp.name
+      vapp_name = @vapp.name
       script = ERB.new(File.read(script_path), nil, '>-').result(binding)
       # vCloud can only handle preamble scripts < 2048 bytes
       if script.bytesize >= 2048 
@@ -109,7 +108,7 @@ module Vcloud
     end
 
     def virtual_hardware_section
-      vm[:'ovf:VirtualHardwareSection'][:'ovf:Item']
+      @vcloud_attributes[:'ovf:VirtualHardwareSection'][:'ovf:Item']
     end
 
   private

--- a/spec/support/stub_fog_interface.rb
+++ b/spec/support/stub_fog_interface.rb
@@ -48,4 +48,5 @@ class StubFogInterface
     { :href => '/vappTemplate-12345678-90ab-cdef-0123-4567890abcde' }
   end
 
+
 end

--- a/spec/vcloud/vm_spec.rb
+++ b/spec/vcloud/vm_spec.rb
@@ -36,8 +36,8 @@ describe Vcloud::Vm do
             ]
         }
     }
-    @vm = Vcloud::Vm.new(@fog_interface, @mock_vm, @mock_vapp)
-
+    Vcloud::FogServiceInterface.stub(:new).and_return(@fog_interface)
+    @vm = Vcloud::Vm.new(@mock_vm, @mock_vapp)
   end
 
   describe '#update_memory_size_in_mb' do


### PR DESCRIPTION
vm knows about the vcloud_attributes and parent vapp.

Also fixed a bug in vm, where logging in rescue block fails since the
variable we are printing is not available
