### PR TITLE
VM Memory is MB, not KB

### DIFF
--- a/lib/vcloud/fog_service_interface.rb
+++ b/lib/vcloud/fog_service_interface.rb
@@ -55,7 +55,7 @@ module Vcloud
     end
 
     def put_memory(vm_id, memory)
-      Vcloud.logger.info("putting #{memory}KB memory into VM #{vm_id}")
+      Vcloud.logger.info("putting #{memory}MB memory into VM #{vm_id}")
       task = @vcloud.put_memory(vm_id, memory).body
       @vcloud.process_task(task)
     end


### PR DESCRIPTION
This commit addresses the log message when configuring VM memory.

Wrong:

```
INFO -- : putting 4096KB memory into VM
```

Right:

```
INFO -- : putting 4096MB memory into VM
```

This should avoid me thinking that I have just created a VM with 4MB of
memory...
