### PR TITLE
code coverage with simplecov

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,26 @@
+require 'simplecov'
+
+SimpleCov.adapters.define 'gem' do
+  add_filter '/spec/'
+  add_filter '/features/'
+  add_filter '/vendor/'
+
+  add_group 'Libraries', '/lib/'
+end
+
+SimpleCov.start 'gem'
+
 require 'bundler/setup'
 require 'vcloud'
 require 'support/stub_fog_interface.rb'
+
+
+SimpleCov.at_exit do
+  SimpleCov.result.format!
+  # do not change the coverage percentage, instead add more unit tests to fix coverage failures.
+  if SimpleCov.result.covered_percent < 70
+    print "ERROR::BAD_COVERAGE\n"
+    print "Coverage is less than acceptable limit. Please add more tests to improve the coverage"
+    exit(1)
+  end
+end

--- a/vcloud-tools.gemspec
+++ b/vcloud-tools.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.14.1'
   s.add_development_dependency 'rspec-mocks', '~> 2.14.4'
+  s.add_development_dependency 'simplecov', '~> 0.8.2'
 end


### PR DESCRIPTION
using SimpleCov to calculate code coverage by unit tests.

Failing spec task, if unit test coverage is below 70%.
