### PR TITLE
Expose underlying fog VCloudDirector object

### DIFF
--- a/lib/vcloud/fog_model_interface.rb
+++ b/lib/vcloud/fog_model_interface.rb
@@ -1,5 +1,7 @@
 module Vcloud
   class FogModelInterface
+    attr_reader :vcloud
+
     def initialize
       @vcloud = Fog::Compute::VcloudDirector.new
     end

--- a/spec/vcloud/fog_model_interface_spec.rb
+++ b/spec/vcloud/fog_model_interface_spec.rb
@@ -22,4 +22,8 @@ describe Vcloud::FogModelInterface do
 
     Vcloud::FogModelInterface.new.get_vm_by_href(vm_href).should == vm
   end
+
+  it "should expose the underlying vcloud fog model" do
+    Vcloud::FogModelInterface.new.vcloud.should_not be_nil
+  end
 end


### PR DESCRIPTION
As a consumer of vcloud-tools if I have instantiated a FogModelInterface
let me access the underlying vcloud object.

Please can you update the SemVersion and provide a TAG.
