### PR TITLE
build should fail if setup data is missing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,18 +29,6 @@ RSpec::Core::RakeTask.new(:spec) do |task|
 end
 
 RSpec::Core::RakeTask.new(:integration_test) do |task|
-  if ENV['VCLOUD_TEST_VDC'].nil?
-    puts 'You must set VCLOUD_TEST_VDC to the name of your vDC'
-    exit
-  end
-  if ENV['VCLOUD_TEST_CATALOG'].nil?
-    puts 'You must set VCLOUD_TEST_CATALOG to the name of your org catalog'
-    exit
-  end
-  if ENV['VCLOUD_TEST_TEMPLATE'].nil?
-    puts 'You must set VCLOUD_TEST_TEMPLATE to the name of your vapp template'
-    exit
-  end
   task.pattern = FileList['spec/integration/*_spec.rb']
 end
 


### PR DESCRIPTION
Removed the checks in RakeFile which used to return zeo exit status if certain env
variables are missing. 

this is no longer required, since we have default
values for these variables.

cc @danielabel : please take a look.
