### PR TITLE
spec clean up

### DIFF
--- a/spec/vcloud/vm_spec.rb
+++ b/spec/vcloud/vm_spec.rb
@@ -38,54 +38,49 @@ describe Vcloud::Vm do
     @vm = Vcloud::Vm.new(@mock_vm, @mock_vapp)
   end
 
-
-  describe '#update_memory_size_in_mb' do
-    context "update memory in VM" do
-      it "should not allow memory size < 64MB" do
-        @fog_interface.should_not_receive(:put_memory)
-        @vm.update_memory_size_in_mb(63)
-      end
-      it "should not update memory if is size has not changed" do
-        @fog_interface.should_not_receive(:put_memory)
-        @vm.update_memory_size_in_mb(@mock_vm_memory_size)
-      end
-      it "should gracefully handle a nil memory size" do
-        @fog_interface.should_not_receive(:put_memory)
-        @vm.update_memory_size_in_mb(nil)
-      end
-      it "should set memory size 64MB" do
-        @fog_interface.should_receive(:put_memory).with(@vm_id, 64)
-        @vm.update_memory_size_in_mb(64)
-      end
-      it "should set memory size 4096MB" do
-        @fog_interface.should_receive(:put_memory).with(@vm_id, 4096)
-        @vm.update_memory_size_in_mb(4096)
-      end
+  context "update memory in VM" do
+    it "should not allow memory size < 64MB" do
+      @fog_interface.should_not_receive(:put_memory)
+      @vm.update_memory_size_in_mb(63)
+    end
+    it "should not update memory if is size has not changed" do
+      @fog_interface.should_not_receive(:put_memory)
+      @vm.update_memory_size_in_mb(@mock_vm_memory_size)
+    end
+    it "should gracefully handle a nil memory size" do
+      @fog_interface.should_not_receive(:put_memory)
+      @vm.update_memory_size_in_mb(nil)
+    end
+    it "should set memory size 64MB" do
+      @fog_interface.should_receive(:put_memory).with(@vm_id, 64)
+      @vm.update_memory_size_in_mb(64)
+    end
+    it "should set memory size 4096MB" do
+      @fog_interface.should_receive(:put_memory).with(@vm_id, 4096)
+      @vm.update_memory_size_in_mb(4096)
     end
   end
 
-  describe '#update_cpu_count' do
-    context "update the number of cpus in vm" do
-      it "should gracefully handle nil cpu count" do
-        @fog_interface.should_not_receive(:put_cpu)
-        @vm.update_cpu_count(nil)
-      end
-      it "should not update cpu if is count has not changed" do
-        @fog_interface.should_not_receive(:put_cpu)
-        @vm.update_cpu_count(@mock_vm_cpu_count)
-      end
-      it "should not allow a zero cpu count" do
-        @fog_interface.should_not_receive(:put_cpu)
-        @vm.update_cpu_count(0)
-      end
-      it "should update cpu count in input is ok" do
-        @fog_interface.should_receive(:put_cpu).with(@vm_id, 2)
-        @vm.update_cpu_count(2)
-      end
+  context "update the number of cpus in vm" do
+    it "should gracefully handle nil cpu count" do
+      @fog_interface.should_not_receive(:put_cpu)
+      @vm.update_cpu_count(nil)
+    end
+    it "should not update cpu if is count has not changed" do
+      @fog_interface.should_not_receive(:put_cpu)
+      @vm.update_cpu_count(@mock_vm_cpu_count)
+    end
+    it "should not allow a zero cpu count" do
+      @fog_interface.should_not_receive(:put_cpu)
+      @vm.update_cpu_count(0)
+    end
+    it "should update cpu count in input is ok" do
+      @fog_interface.should_receive(:put_cpu).with(@vm_id, 2)
+      @vm.update_cpu_count(2)
     end
   end
 
-  describe '#generate_preamble' do
+  context '#generate_preamble' do
     it "should interpolate vars hash into template" do
       vars = {:message => 'hello world'}
       erbfile = "#{@data_dir}/basic_preamble_test.erb"
@@ -95,100 +90,93 @@ describe Vcloud::Vm do
 
   end
 
-  describe '#update_metadata' do
-    context "it should update the key+value vm+vapp metadata" do
-      it "should handle empty metadata hash" do
-        @fog_interface.should_not_receive(:put_vapp_metadata_value)
-        @vm.update_metadata(nil)
-      end
-      it "should handle metadata of multiple types" do
-        @fog_interface.should_receive(:put_vapp_metadata_value).with(@vm_id, :foo, 'bar')
-        @fog_interface.should_receive(:put_vapp_metadata_value).with(@vm_id, :false_thing, false)
-        @fog_interface.should_receive(:put_vapp_metadata_value).with(@vm_id, :true_thing, true)
-        @fog_interface.should_receive(:put_vapp_metadata_value).with(@vm_id, :number, 53)
-        @fog_interface.should_receive(:put_vapp_metadata_value).with(@vm_id, :zero, 0)
-        @fog_interface.should_receive(:put_vapp_metadata_value).with(@vapp_id, :foo, 'bar')
-        @fog_interface.should_receive(:put_vapp_metadata_value).with(@vapp_id, :false_thing, false)
-        @fog_interface.should_receive(:put_vapp_metadata_value).with(@vapp_id, :true_thing, true)
-        @fog_interface.should_receive(:put_vapp_metadata_value).with(@vapp_id, :number, 53)
-        @fog_interface.should_receive(:put_vapp_metadata_value).with(@vapp_id, :zero, 0)
-        @vm.update_metadata(@mock_metadata)
-      end
+  context "update metadata" do
+    it "should handle empty metadata hash" do
+      @fog_interface.should_not_receive(:put_vapp_metadata_value)
+      @vm.update_metadata(nil)
+    end
+    it "should handle metadata of multiple types" do
+      @fog_interface.should_receive(:put_vapp_metadata_value).with(@vm_id, :foo, 'bar')
+      @fog_interface.should_receive(:put_vapp_metadata_value).with(@vm_id, :false_thing, false)
+      @fog_interface.should_receive(:put_vapp_metadata_value).with(@vm_id, :true_thing, true)
+      @fog_interface.should_receive(:put_vapp_metadata_value).with(@vm_id, :number, 53)
+      @fog_interface.should_receive(:put_vapp_metadata_value).with(@vm_id, :zero, 0)
+      @fog_interface.should_receive(:put_vapp_metadata_value).with(@vapp_id, :foo, 'bar')
+      @fog_interface.should_receive(:put_vapp_metadata_value).with(@vapp_id, :false_thing, false)
+      @fog_interface.should_receive(:put_vapp_metadata_value).with(@vapp_id, :true_thing, true)
+      @fog_interface.should_receive(:put_vapp_metadata_value).with(@vapp_id, :number, 53)
+      @fog_interface.should_receive(:put_vapp_metadata_value).with(@vapp_id, :zero, 0)
+      @vm.update_metadata(@mock_metadata)
     end
   end
 
-  describe '#configure_network_interfaces' do
+  context "configure vm network interfaces" do
+    it "should configure single nic without an IP" do
+      network_config = [{:name => 'Default'}]
+      @fog_interface.should_receive(:put_network_connection_system_section_vapp).with(@vm_id, {
+          :PrimaryNetworkConnectionIndex => 0,
+          :NetworkConnection => [
+              {
+                  :network => 'Default',
+                  :needsCustomization => true,
+                  :NetworkConnectionIndex => 0,
+                  :IsConnected => true,
+                  :IpAddressAllocationMode => "DHCP"
+              }
+          ]})
+      @vm.configure_network_interfaces(network_config)
+    end
 
-    context "configure vm network connections" do
+    it "should configure single nic" do
+      network_config = [{:name => 'Default', :ip_address => '192.168.1.1'}]
+      @fog_interface.should_receive(:put_network_connection_system_section_vapp).with(@vm_id, {
+          :PrimaryNetworkConnectionIndex => 0,
+          :NetworkConnection => [
+              {
+                  :network => 'Default',
+                  :needsCustomization => true,
+                  :NetworkConnectionIndex => 0,
+                  :IsConnected => true,
+                  :IpAddress => "192.168.1.1",
+                  :IpAddressAllocationMode => "MANUAL"
+              }
+          ]})
+      @vm.configure_network_interfaces(network_config)
+    end
 
-      it "should configure single nic without an IP" do
-        network_config = [{:name => 'Default'}]
-        @fog_interface.should_receive(:put_network_connection_system_section_vapp).with(@vm_id, {
-            :PrimaryNetworkConnectionIndex => 0,
-            :NetworkConnection => [
-                {
-                    :network => 'Default',
-                    :needsCustomization => true,
-                    :NetworkConnectionIndex => 0,
-                    :IsConnected => true,
-                    :IpAddressAllocationMode => "DHCP"
-                }
-            ]})
-        @vm.configure_network_interfaces(network_config)
-      end
+    it "should configure multiple nics" do
+      network_config = [
+          {:name => 'Default', :ip_address => '192.168.1.1'},
+          {:name => 'Monitoring', :ip_address => '192.168.2.1'}
+      ]
 
-      it "should configure single nic" do
-        network_config = [{:name => 'Default', :ip_address => '192.168.1.1'}]
-        @fog_interface.should_receive(:put_network_connection_system_section_vapp).with(@vm_id, {
-            :PrimaryNetworkConnectionIndex => 0,
-            :NetworkConnection => [
-                {
-                    :network => 'Default',
-                    :needsCustomization => true,
-                    :NetworkConnectionIndex => 0,
-                    :IsConnected => true,
-                    :IpAddress => "192.168.1.1",
-                    :IpAddressAllocationMode => "MANUAL"
-                }
-            ]})
-        @vm.configure_network_interfaces(network_config)
-      end
+      @fog_interface.should_receive(:put_network_connection_system_section_vapp).with(@vm_id, {
+          :PrimaryNetworkConnectionIndex => 0,
+          :NetworkConnection => [
+              {
+                  :network => 'Default',
+                  :needsCustomization => true,
+                  :NetworkConnectionIndex => 0,
+                  :IsConnected => true,
+                  :IpAddress => "192.168.1.1",
+                  :IpAddressAllocationMode => "MANUAL"
+              },
+              {
+                  :network => 'Monitoring',
+                  :needsCustomization => true,
+                  :NetworkConnectionIndex => 1,
+                  :IsConnected => true,
+                  :IpAddress => "192.168.2.1",
+                  :IpAddressAllocationMode => "MANUAL"
+              },
+          ]})
+      @vm.configure_network_interfaces(network_config)
+    end
 
-      it "should configure multiple nics" do
-        network_config = [
-            {:name => 'Default', :ip_address => '192.168.1.1'},
-            {:name => 'Monitoring', :ip_address => '192.168.2.1'}
-        ]
-
-        @fog_interface.should_receive(:put_network_connection_system_section_vapp).with(@vm_id, {
-            :PrimaryNetworkConnectionIndex => 0,
-            :NetworkConnection => [
-                {
-                    :network => 'Default',
-                    :needsCustomization => true,
-                    :NetworkConnectionIndex => 0,
-                    :IsConnected => true,
-                    :IpAddress => "192.168.1.1",
-                    :IpAddressAllocationMode => "MANUAL"
-                },
-                {
-                    :network => 'Monitoring',
-                    :needsCustomization => true,
-                    :NetworkConnectionIndex => 1,
-                    :IsConnected => true,
-                    :IpAddress => "192.168.2.1",
-                    :IpAddressAllocationMode => "MANUAL"
-                },
-            ]})
-        @vm.configure_network_interfaces(network_config)
-      end
-
-      it "should configure no nics" do
-        network_config = nil
-        @fog_interface.should_not_receive(:put_network_connection_system_section_vapp)
-        @vm.configure_network_interfaces(network_config)
-      end
-
+    it "should configure no nics" do
+      network_config = nil
+      @fog_interface.should_not_receive(:put_network_connection_system_section_vapp)
+      @vm.configure_network_interfaces(network_config)
     end
 
   end


### PR DESCRIPTION
removed the duplicate describe blocks, which wraps single context
block. 

cc: @danielabel 
