### PR TITLE
Pending tests muddy the output

### DIFF
--- a/spec/vcloud/query_spec.rb
+++ b/spec/vcloud/query_spec.rb
@@ -101,7 +101,7 @@ describe Vcloud::Query do
         @query.run()
       end
 
-      it "should output a query in yaml when run with a type"
+#      it "should output a query in yaml when run with a type"
 
     end
 


### PR DESCRIPTION
Commenting out is a code smell but better than a pending test as it muddies the output of `bx rake spec` making it harder to spot a genuine failing test.

I didn't realise this until I just ran it, but if you leave a test without a body you get this:

```
..............*..........DEPRECATION: mock is deprecated. Use double instead. Called from /Users/annashipman/projects/govuk/vcloud-tools/spec/vcloud/vapp_spec.rb:141:in `block (3 levels) in <top (required)>'.
...........................

Pending:
  Vcloud::Query attributes get results with a single response page should output a query in yaml when run with a type
    # Not yet implemented
    # ./spec/vcloud/query_spec.rb:104

Finished in 0.0741 seconds
52 examples, 0 failures, 1 pending
Coverage report generated for RSpec to /Users/annashipman/projects/govuk/vcloud-tools/coverage. 340 / 454 LOC (74.89%) covered.
```

If the test is commented out you get this:

```
........................DEPRECATION: mock is deprecated. Use double instead. Called from /Users/annashipman/projects/govuk/vcloud-tools/spec/vcloud/vapp_spec.rb:141:in `block (3 levels) in <top (required)>'.
...........................

Finished in 0.07252 seconds
51 examples, 0 failures
Coverage report generated for RSpec to /Users/annashipman/projects/govuk/vcloud-tools/coverage. 340 / 454 LOC (74.89%) covered.
```

The former looks similar to a failing test. I only want to see actually failing tests here.
