### PR TITLE
run only integration tests in integration test run

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,7 @@ RSpec::Core::RakeTask.new(:spec) do |task|
 end
 
 RSpec::Core::RakeTask.new(:integration_test) do |task|
-  task.pattern = FileList['spec/integration/*_spec.rb']
+  task.pattern = FileList['spec/integration/**/*_spec.rb']
 end
 
 task :default => [:spec,:features]


### PR DESCRIPTION
Rake file match was finding nothing, so must be failing over to default behaviours to run tests - this change should ensure the integration tests run. 

/cc @snehaso 
