### PR TITLE
fix to instantiate-vapp-with-defaults case

### DIFF
--- a/lib/vcloud/core/vapp.rb
+++ b/lib/vcloud/core/vapp.rb
@@ -76,8 +76,8 @@ module Vcloud
       end
 
       def build_network_config(networks)
-        instantiation = {NetworkConfigSection: {NetworkConfig: []}}
-        return instantiation unless networks
+        return {} unless networks
+        instantiation = { NetworkConfigSection: {NetworkConfig: []} }
         networks.compact.each do |network|
           instantiation[:NetworkConfigSection][:NetworkConfig] << {
               networkName: network[:name],


### PR DESCRIPTION
Was causing integration test for the minimal setup to fail in certain organisations.
