### PR TITLE
resolving namespace clashes

### DIFF
--- a/lib/vcloud/core.rb
+++ b/lib/vcloud/core.rb
@@ -1,3 +1,5 @@
+require 'vcloud/fog'
+
 require 'vcloud/core/entity'
 require 'vcloud/core/metadata_helper'
 require 'vcloud/core/compute_metadata'

--- a/lib/vcloud/core/compute_metadata.rb
+++ b/lib/vcloud/core/compute_metadata.rb
@@ -3,7 +3,7 @@ module Vcloud
     module ComputeMetadata
 
         def get_metadata id
-          vcloud_compute_metadata =  Fog::ServiceInterface.new.get_vapp_metadata(id)
+          vcloud_compute_metadata =  Vcloud::Fog::ServiceInterface.new.get_vapp_metadata(id)
           MetadataHelper.extract_metadata(vcloud_compute_metadata[:MetadataEntry])
         end
 


### PR DESCRIPTION
- Vcloud::Fog namespace is present both in vcloud-walker and vcloud-tools. This causes conflict.Resolving it by providing full namespace.
- Also core should require fog classes. This is must when we require core in opinionated/opinionated tools.
