### PR TITLE
The defaults don't work, they just make it worse

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,15 @@ VM. The easiest thing to do is create a local shell script called
 `vcloud_env.sh` and set the contents:
 
     export FOG\_CREDENTIAL=test
-    export VCLOUD\_TEST\_VDC="Name of the VDC"
-    export VCLOUD\_TEST\_CATALOG="catalog-name"
-    export VCLOUD\_TEST\_TEMPLATE="name-of-template"
-    export VCLOUD\_TEST\_NETWORK1="name-of-primary-network"
-    export VCLOUD\_TEST\_NETWORK2="name-of-secondary-network"
-    export VCLOUD\_TEST\_NETWORK1_IP="ip-on-primary-network"
-    export VCLOUD\_TEST\_NETWORK2_IP="ip-on-secondary-network"
+    export VCLOUD\_VDC\_NAME="Name of the VDC"
+    export VCLOUD\_CATALOG\_NAME="catalog-name"
+    export VCLOUD\_TEMPLATE\_NAME="name-of-template"
+    export VCLOUD\_NETWORK1\_NAME="name-of-primary-network"
+    export VCLOUD\_NETWORK2\_NAME="name-of-secondary-network"
+    export VCLOUD\_NETWORK1\_IP="ip-on-primary-network"
+    export VCLOUD\_NETWORK2\_IP="ip-on-secondary-network"
+    export VCLOUD\_TEST\_STORAGE\_PROFILE="storage-profile-name"
+    export VCLOUD\_TEST\_STORAGE\_PROFILE_HREF="url-of-named-storage-profile"
 
 Then run this before you run the integration test.
 

--- a/spec/integration/launcher/vcloud_launcher_spec.rb
+++ b/spec/integration/launcher/vcloud_launcher_spec.rb
@@ -155,15 +155,14 @@ end
 
 def define_test_data
   {
-      vapp_name: "vapp-vcloud-tools-tests-#{Time.now.strftime('%s')}",
-      vdc_name: ENV['VCLOUD_TEST_VDC'],
-      catalog: ENV['VCLOUD_TEST_CATALOG'],
-      vapp_template: ENV['VCLOUD_TEST_TEMPLATE'],
-      network1: ENV['VCLOUD_TEST_NETWORK1'],
-      network2: ENV['VCLOUD_TEST_NETWORK2'],
-      network1_ip: ENV['VCLOUD_TEST_NETWORK1_IP'],
-      network2_ip: ENV['VCLOUD_TEST_NETWORK2_IP'],
-      storage_profile: ENV['VCLOUD_TEST_STORAGE_PROFILE'],
+      vdc_name: ENV['VCLOUD_VDC_NAME'],
+      catalog: ENV['VCLOUD_CATALOG_NAME'],
+      vapp_template: ENV['VCLOUD_TEMPLATE_NAME'],
+      network1: ENV['VCLOUD_NETWORK1_NAME'],
+      network2: ENV['VCLOUD_NETWORK2_NAME'],
+      network1_ip: ENV['VCLOUD_NETWORK1_IP'],
+      network2_ip: ENV['VCLOUD_NETWORK2_IP'],
+      storage_profile: ENV['VCLOUD_STORAGE_PROFILE_NAME'],
       storage_profile_href: ENV['VCLOUD_TEST_STORAGE_PROFILE_HREF'], # https://vcloud.examples.net/api/vdcStorageProfile/1
       bootstrap_script: File.join(File.dirname(__FILE__), "data/basic_preamble_test.erb"),
       date_metadata: DateTime.parse('2013-10-23 15:34:00 +0000')


### PR DESCRIPTION
I've altered the defaults in the integration tests to be comments instead as I believe that they aren't helping the code fail fast, or with an error the developer will recognise. 

The next step would be to fail if all these aren't set, but feels too constraining.

@snehaso @annashipman @mikepea 
