### PR TITLE
Ensure Errors bubble up in Query tool

### DIFF
--- a/lib/vcloud/query.rb
+++ b/lib/vcloud/query.rb
@@ -62,7 +62,7 @@ module Vcloud
         body = @fsi.get_execute_query(type=@type, @options.merge({:page=>page}))
         pp body if @options[:debug]
       rescue ::Fog::Compute::VcloudDirector::BadRequest, ::Fog::Compute::VcloudDirector::Forbidden => e
-        Kernel.abort("#{File.basename($0)}: #{e.message}")
+        raise "Access denied: #{e.message}"
       end
 
       records = body.keys.detect {|key| key.to_s =~ /Record|Reference$/}


### PR DESCRIPTION
- rather than abort - throw exception - to avoid headaches later. 
- also fixed the name-spacing so tool doesn't break on receipt of fog exceptions.
