### PR TITLE
vapp clean up- extracted out orchestrator

### DIFF
--- a/lib/vcloud.rb
+++ b/lib/vcloud.rb
@@ -14,6 +14,7 @@ require 'vcloud/core'
 require 'vcloud/config_loader'
 require 'vcloud/launch'
 require 'vcloud/query'
+require 'vcloud/vapp_orchestrator'
 
 module Vcloud
 

--- a/lib/vcloud/core/vapp.rb
+++ b/lib/vcloud/core/vapp.rb
@@ -7,6 +7,7 @@ module Vcloud
 
       def initialize(vcloud_attributes = {})
         @vcloud_attributes = vcloud_attributes
+        @fog_interface = Vcloud::Fog::ServiceInterface.new
       end
 
       module STATUS
@@ -22,7 +23,7 @@ module Vcloud
         link ? link[:href].split('/').last : raise('a vapp without parent vdc found')
       end
 
-      def vms
+      def fog_vms
         @vcloud_attributes[:Children][:Vm]
       end
 
@@ -30,49 +31,40 @@ module Vcloud
         @vcloud_attributes[:'ovf:NetworkSection'][:'ovf:Network']
       end
 
-      def provision(config)
+      def self.get_by_name_and_vdc_name(name, vdc_name)
         fog_interface = Vcloud::Fog::ServiceInterface.new
-        name, vdc_name = config[:name], config[:vdc_name]
-        begin
-          if @vcloud_attributes = fog_interface.get_vapp_by_name_and_vdc_name(name, vdc_name)
-            Vcloud.logger.info("Found existing vApp #{name} in vDC '#{vdc_name}'. Skipping.")
-          else
-            template = Vcloud::Core::VappTemplate.get(config[:catalog], config[:catalog_item])
-            template_id = template.id
+        vcloud_attributes = fog_interface.get_vapp_by_name_and_vdc_name(name, vdc_name)
+        new(vcloud_attributes) if vcloud_attributes
+      end
 
-            if (config[:vm] && config[:vm][:network_connections])
-              network_names = config[:vm][:network_connections].collect { |h| h[:name] }
-              networks = fog_interface.find_networks(network_names, vdc_name)
-            end
+      def reload
+        @fog_interface.get_vapp(id)
+      end
 
-            Vcloud.logger.info("Instantiating new vApp #{name} in vDC '#{vdc_name}'")
-            @vcloud_attributes = fog_interface.post_instantiate_vapp_template(
-                fog_interface.vdc(vdc_name),
-                template_id,
-                name,
-                InstantiationParams: build_network_config(networks)
-            )
-            VmOrchestrator.new(vms.first, self).customize(config[:vm]) if config[:vm]
-            @vcloud_attributes = fog_interface.get_vapp(id)
-          end
+      def instantiate(name, network_names, template_id, vdc_name)
+        Vcloud.logger.info("Instantiating new vApp #{name} in vDC '#{vdc_name}'")
+        networks = get_networks(network_names, vdc_name)
 
-        rescue RuntimeError => e
-          Vcloud.logger.error("Could not provision vApp: #{e.message}")
-        end
+        @vcloud_attributes = @fog_interface.post_instantiate_vapp_template(
+            @fog_interface.vdc(vdc_name),
+            template_id,
+            name,
+            InstantiationParams: build_network_config(networks)
+        )
         self
       end
 
       def power_on
         raise "Cannot power on a missing vApp." unless id
         return true if running?
-        Vcloud::Fog::ServiceInterface.new.power_on_vapp(id)
+        @fog_interface.power_on_vapp(id)
         running?
       end
 
       private
       def running?
         raise "Cannot call running? on a missing vApp." unless id
-        vapp = Vcloud::Fog::ServiceInterface.new.get_vapp(id)
+        vapp = @fog_interface.get_vapp(id)
         vapp[:status].to_i == STATUS::RUNNING ? true : false
       end
 
@@ -93,6 +85,10 @@ module Vcloud
 
       def id_prefix
         'vapp'
+      end
+
+      def get_networks(network_names, vdc_name)
+        @fog_interface.find_networks(network_names, vdc_name) if network_names
       end
     end
   end

--- a/lib/vcloud/core/vm_orchestrator.rb
+++ b/lib/vcloud/core/vm_orchestrator.rb
@@ -1,8 +1,8 @@
 module Vcloud
   module Core
     class VmOrchestrator
-      def initialize vm, vapp
-        @vm = Vm.new(vm, vapp)
+      def initialize fog_vm, vapp
+        @vm = Vm.new(fog_vm, vapp)
       end
 
       def customize(vm_config)

--- a/lib/vcloud/launch.rb
+++ b/lib/vcloud/launch.rb
@@ -18,8 +18,7 @@ module Vcloud
 
       config[:vapps].each do |vapp_config|
         Vcloud.logger.info("Configuring vApp #{vapp_config[:name]}.")
-        vapp = Vcloud::Core::Vapp.new
-        vapp.provision(vapp_config)
+        vapp = ::Vcloud::VappOrchestrator.provision(vapp_config)
         vapp.power_on unless @cli_options[:no_power_on]
       end
     end

--- a/lib/vcloud/vapp_orchestrator.rb
+++ b/lib/vcloud/vapp_orchestrator.rb
@@ -1,0 +1,32 @@
+module Vcloud
+  class VappOrchestrator
+
+    def self.provision(vapp_config)
+      name, vdc_name = vapp_config[:name], vapp_config[:vdc_name]
+      begin
+        if vapp = Vcloud::Core::Vapp.get_by_name_and_vdc_name(name, vdc_name)
+          Vcloud.logger.info("Found existing vApp #{name} in vDC '#{vdc_name}'. Skipping.")
+        else
+          template = Vcloud::Core::VappTemplate.get(vapp_config[:catalog], vapp_config[:catalog_item])
+          template_id = template.id
+
+          network_names = extract_vm_networks(vapp_config)
+          vapp = Vcloud::Core::Vapp.new.instantiate(name, network_names, template_id, vdc_name)
+          Vcloud::Core::VmOrchestrator.new(vapp.fog_vms.first, vapp).customize(vapp_config[:vm]) if vapp_config[:vm]
+          vapp.reload
+        end
+
+      rescue RuntimeError => e
+        Vcloud.logger.error("Could not provision vApp: #{e.message}")
+      end
+      vapp
+    end
+
+    def self.extract_vm_networks(config)
+      if (config[:vm] && config[:vm][:network_connections])
+        config[:vm][:network_connections].collect { |h| h[:name] }
+      end
+    end
+
+  end
+end

--- a/spec/vcloud/vapp_orchestrator_spec.rb
+++ b/spec/vcloud/vapp_orchestrator_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+module Vcloud
+
+  describe VappOrchestrator do
+
+    context "provision a vapp" do
+
+      before(:all) do
+        @config = {
+            :name => 'test-vapp-1',
+            :vdc_name => 'test-vdc-1',
+            :catalog => 'org-1-catalog',
+            :catalog_item => 'org-1-template',
+            :vm => {
+                :network_connections => [{:name => 'org-vdc-1-net-1'}]
+            }
+        }
+      end
+
+      it "should return a vapp if it already exists" do
+        existing_vapp = double(:vapp, :name => 'existing-vapp-1')
+
+        Core::Vapp.should_receive(:get_by_name_and_vdc_name).with('test-vapp-1', 'test-vdc-1').and_return(existing_vapp)
+        actual_vapp = VappOrchestrator.provision @config
+        actual_vapp.should_not be_nil
+        actual_vapp.should == existing_vapp
+      end
+
+      it "should create a vapp if it does not exist" do
+        #this test highlights the problems in vapp
+        mock_fog_vm = double(:vm)
+        mock_vapp = double(:vapp, :fog_vms => [mock_fog_vm], :reload => self)
+        mock_vm_orchestrator = double(:vm_orchestrator, :customize => true)
+
+
+        Core::Vapp.should_receive(:get_by_name_and_vdc_name).with('test-vapp-1', 'test-vdc-1').and_return(nil)
+        Core::VappTemplate.should_receive(:get).with('org-1-catalog', 'org-1-template').and_return(double(:vapp_template, :id => 1))
+
+        Core::Vapp.any_instance.should_receive(:instantiate).with('test-vapp-1', ['org-vdc-1-net-1'], 1, 'test-vdc-1')
+        .and_return(mock_vapp)
+        Core::VmOrchestrator.should_receive(:new).with(mock_fog_vm, mock_vapp).and_return(mock_vm_orchestrator)
+
+        new_vapp = VappOrchestrator.provision @config
+        new_vapp.should == mock_vapp
+      end
+
+      it "should log the error and swallow the exception if there is no template" do
+        Core::Vapp.should_receive(:get_by_name_and_vdc_name).with('test-vapp-1', 'test-vdc-1').and_return(nil)
+        Core::VappTemplate.should_receive(:get).with('org-1-catalog', 'org-1-template').and_raise('Could not find template vApp')
+
+        Vcloud.logger.should_receive(:error).with("Could not provision vApp: Could not find template vApp")
+        VappOrchestrator.provision @config
+      end
+
+    end
+  end
+end
+


### PR DESCRIPTION
- broke `Vapp.new.provision` methods into small methods. 
- extracted out `VappOrchestrator` from `Vapp`
