### PR TITLE
resolving gemfile & gemspec conflict

### DIFF
--- a/vcloud-tools.gemspec
+++ b/vcloud-tools.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.2'
 
   s.add_runtime_dependency 'bundler'
-  s.add_runtime_dependency 'fog', '~> 1.18.0'
+  s.add_runtime_dependency 'fog', '>= 1.18.0'
   s.add_runtime_dependency 'methadone'
   s.add_runtime_dependency 'thor', '~> 0.18.1'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
conflicts happens because gemspec expects a particular
version of 'fog' gem, whereas Gemfile tries
to use the latest master version

resolved this conflict by changing gemspec to accept a version
greater than to equal to a particular version. this allows user to override version in Gemfile.
