### PR TITLE
Internalise two of the VSE examples

### DIFF
--- a/docs/edgegateway.md
+++ b/docs/edgegateway.md
@@ -19,11 +19,91 @@ but the mechanism is the same for updating any Edge Gateway service.<br/>You can
 
 ###Examples:
 
-Examples for configuring different services:
+Service examples, to be used in place of the `configuration` object above.
 
-firewall => https://gist.github.com/snehaso/cd839ac05c640b954bed
+Firewall:
+```ruby
+configuration = {
+  :FirewallService => {
+    :IsEnabled => true,
+    :DefaultAction => 'allow',
+    :LogDefaultAction => false,
+    :FirewallRule => [
+      {
+        :Policy => 'allow',
+        :Description => 'description',
+        :Protocols => {:Tcp => true},
+        :Port => 22,
+        :DestinationPortRange => 22,
+        :DestinationIp => 'Internal',
+        :SourcePort => 22,
+        :SourceIp => 'External',
+        :SourcePortRange => '22'
+      }
+    ]
+  }
+}
+```
 
-load-balancer => https://gist.github.com/snehaso/20c080d0ec0ba7a00611
+Load balancer:
+```ruby
+configuration = {
+  :LoadBalancerService => {
+    :IsEnabled => "true",
+    :Pool => [
+      {
+        :Name => 'web-app',
+        :ServicePort => [
+          {
+            :IsEnabled => "true",
+            :Protocol => "HTTP",
+            :Algorithm => "ROUND_ROBIN",
+            :Port => 80,
+            :HealthCheckPort => 80,
+            :HealthCheck => {
+              :Mode => "HTTP", :HealthThreshold => 1, :UnhealthThreshold => 6, :Interval => 20, :Timeout => 25
+            }
+          },
+          {
+            :IsEnabled => true,
+            :Protocol => "HTTPS",
+            :Algorithm => "ROUND_ROBIN",
+            :Port => 443,
+            :HealthCheckPort => 443,
+            :HealthCheck => {
+              :Mode => "SSL", :HealthThreshold => 1, :UnhealthThreshold => 6, :Interval => 20, :Timeout => 25
+            }
+          }
+        ],
+        :Member => [
+          {
+            :IpAddress => "192.168.254.100",
+            :Weight => 1,
+            :ServicePort => [
+              {:Protocol => "HTTP", :Port => 80, :HealthCheckPort => 80}
+            ]
+          }
+        ]
+      }
+    ],
+    :VirtualServer => [
+      {
+        :IsEnabled => "true",
+        :Name => "app1",
+        :Description => "app1",
+        :Interface => {:name => "Default", :href => "https://vmware.api.net/api/admin/network/2ad93597-7b54-43dd-9eb1-631dd337e5a7"},
+        :IpAddress => '192.168.2.2',
+        :ServiceProfile => [
+          {:IsEnabled => "true", :Protocol => "HTTP", :Port => 80, :Persistence => {:Method => ""}},
+          {:IsEnabled => "true", :Protocol => "HTTPS", :Port => 443, :Persistence => {:Method => ""}}
+        ],
+        :Logging => false,
+        :Pool => 'web-app'
+      }
+    ]
+  }
+}
+```
 
 nat => https://gist.github.com/snehaso/e5ae5767fe1ac2e4e98d
 


### PR DESCRIPTION
Rather than linking out to personal gists. Because Sneha may not keep them
forever, and they should be version controlled here.

The NAT example is missing because GitHub currently returns:

```
Hm.

This gist can't be viewed at the moment. Please send a message to Support and we'll have a look as soon as we can.
```

@snehaso, do you have another copy of this?
