### PR TITLE
Clarify Fog env var in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Unfortunately current usage of fog requires the password in this file. Multiple 
 
 You can then pass the `FOG_CREDENTIAL` environment variable at the start of your command. The value of the `FOG_CREDENTIAL` environment variable is the name of the credential set in your fog file which you wish to use.  For instance:
 
-    FOG_CREDENTIAL=test2 bundle exec vcloud-query -o yaml vApp
+    FOG_CREDENTIAL=test2 bundle exec vcloud-launch node.yaml
 
 ## Other settings
 


### PR DESCRIPTION
Amends #104:
- clarifies that env var should be used before command
- notes values which env var can accept
