### PR TITLE
[#63716032] utils/vcloud-vapp-delete was broken

### DIFF
--- a/lib/vcloud/core/vapp.rb
+++ b/lib/vcloud/core/vapp.rb
@@ -83,11 +83,6 @@ module Vcloud
         running?
       end
 
-      def delete
-        raise "Cannot delete a running vApp" if running?
-        Vcloud::Fog::ServiceInterface.new.delete_vapp(id)
-      end
-
       private
       def running?
         raise "Cannot call running? on a missing vApp." unless id

--- a/spec/vcloud/core/vapp_spec.rb
+++ b/spec/vcloud/core/vapp_spec.rb
@@ -25,7 +25,6 @@ module Vcloud
         it { should respond_to(:fog_vms) }
         it { should respond_to(:networks) }
         it { should respond_to(:power_on) }
-        it { should respond_to(:delete) }
       end
 
       context "#initialize" do
@@ -74,33 +73,6 @@ module Vcloud
           mock_query = double(:query, :get_all_results => q_results)
           Vcloud::Query.should_receive(:new).with('vApp', :filter => "name==vapp-test-1").and_return(mock_query)
           expect{ Vapp.get_by_name('vapp-test-1') }.to raise_exception(RuntimeError)
-        end
-
-      end
-
-      context "#delete" do
-
-        it "should not delete a running vApp" do
-          vapp = Vapp.new(@vapp_id)
-          @stub_attrs = {
-              :name => @vapp_name,
-              :href => "/#{@vapp_id}",
-              :status => 4,
-          }
-          StubFogInterface.any_instance.stub(:get_vapp).and_return(@stub_attrs)
-          expect { vapp.delete }.to raise_error("Cannot delete a running vApp")
-        end
-
-        it "should delete a not-running vApp" do
-          vapp = Vapp.new(@vapp_id)
-          @stub_attrs = {
-              :name => @vapp_name,
-              :href => "/#{@vapp_id}",
-              :status => 8,
-          }
-          StubFogInterface.any_instance.stub(:get_vapp).and_return(@stub_attrs)
-          @mock_fog_interface.should_receive(:delete_vapp).with(@vapp_id)
-          vapp.delete
         end
 
       end


### PR DESCRIPTION
I needed to delete some vApps during testing, and noticed that vcloud-vapp-delete was broken after we moved to FogServiceInterface.

Fixed it up and added a #delete method to Core::Vapp.
