### PR TITLE
Rspec tagging

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -32,8 +32,8 @@ RSpec::Core::RakeTask.new(:spec) do |task|
   task.pattern = FileList['spec/vcloud/**/*_spec.rb']
 end
 
-RSpec::Core::RakeTask.new('integration:ci') do |t|
-  t.rspec_opts = %w(--tag ~skip_in_ci)
+RSpec::Core::RakeTask.new('integration:quick') do |t|
+  t.rspec_opts = %w(--tag ~take_too_long)
   t.pattern = FileList['spec/integration/**/*_spec.rb']
 end
 

--- a/spec/integration/launcher/storage_profile_integration_spec.rb
+++ b/spec/integration/launcher/storage_profile_integration_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Vcloud::Launch do
-  context "storage profile", :skip_in_ci => true do
+  context "storage profile", :take_too_long => true do
     before(:all) do
       @test_data = define_test_data
       @config_yaml = generate_input_yaml_config(@test_data, File.join(File.dirname(__FILE__), 'data/storage_profile.yaml.erb'))

--- a/spec/integration/org_vdc_network_manual_spec.rb
+++ b/spec/integration/org_vdc_network_manual_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'pp'
 
-describe Vcloud::Core::OrgVdcNetwork, :skip_in_ci => true do
+describe Vcloud::Core::OrgVdcNetwork, :take_too_long => true do
 
   context "natRouted network" do
 


### PR DESCRIPTION
Now we have separate rake tasks to run integration tests for ci and
rest of the world( which is dev boxes)

rake integration:ci skips the manual and time consuming integration tests. 

rake integration:all runs all the integration tests.
