### PR TITLE
added shortcuts for cli options

### DIFF
--- a/bin/vcloud-launch
+++ b/bin/vcloud-launch
@@ -16,8 +16,6 @@ class App
     Launch.new.run(org_config_file, options)
   end
 
-  on("-v", "--verbose", "Verbose output")
-  on("-d", "--debug", "Debugging output")
   on("-x", "--dont-power-on", "Do not power on vApps (default is to power on)")
   on("-c", "--continue-on-error", "Continue on error ( default is false) ")
 

--- a/bin/vcloud-net-launch
+++ b/bin/vcloud-net-launch
@@ -16,8 +16,6 @@ class App
     NetLaunch.new.run(net_config_file, options)
   end
 
-  on("-v", "--verbose", "Verbose output")
-  on("-d", "--debug", "Debugging output")
   on("-m", "--mock", "Fog Mock mode enabled")
 
   arg :net_config_file

--- a/bin/vcloud-query
+++ b/bin/vcloud-query
@@ -42,8 +42,6 @@ class App
   end
 
   on("--mock",    "Fog Mock mode")
-  on("--verbose", "Verbose output")
-  on("--debug",   "Debugging output")
 
   arg :type, :optional
 
@@ -74,7 +72,6 @@ class App
     vcloud-query
 
   '
-
 
   version Vcloud::VERSION
 

--- a/features/vcloud-launch.feature
+++ b/features/vcloud-launch.feature
@@ -10,8 +10,6 @@ Feature: "vcloud-launch" works as a useful command-line tool
     And the banner should document that this app takes options
     And the following options should be documented:
       |--version|
-      |--verbose|
-      |--debug|
       |--dont-power-on|
       |--continue-on-error|
     And the banner should document that this app's arguments are:

--- a/features/vcloud-net-launch.feature
+++ b/features/vcloud-net-launch.feature
@@ -10,8 +10,6 @@ Feature: "vcloud-net-launch" works as a useful command-line tool
     And the banner should document that this app takes options
     And the following options should be documented:
       |--version|
-      |--verbose|
-      |--debug|
       |--mock|
     And the banner should document that this app's arguments are:
       |net_config_file|

--- a/features/vcloud-query.feature
+++ b/features/vcloud-query.feature
@@ -10,8 +10,6 @@ Feature: "vcloud-query" works as a useful command-line tool
     And the banner should document that this app takes options
     And the following options should be documented:
       |--version|
-      |--verbose|
-      |--debug|
       |--mock|
     And the banner should document that this app's arguments are:
       |type|

--- a/lib/vcloud/core/query.rb
+++ b/lib/vcloud/core/query.rb
@@ -27,10 +27,6 @@ module Vcloud
     end
 
     def run()
-
-      puts "options:" if @options[:debug]
-      pp @options if @options[:debug]
-
       if @type.nil?
         output_potential_query_types
       else

--- a/lib/vcloud/launch.rb
+++ b/lib/vcloud/launch.rb
@@ -8,9 +8,6 @@ module Vcloud
     end
 
     def run(config_file = nil, cli_options = {})
-      puts "cli_options:" if cli_options[:debug]
-      pp cli_options if cli_options[:debug]
-
       config = @config_loader.load_config(config_file)
       config[:vapps].each do |vapp_config|
         Vcloud.logger.info("\n")

--- a/lib/vcloud/net_launch.rb
+++ b/lib/vcloud/net_launch.rb
@@ -5,18 +5,13 @@ module Vcloud
   class NetLaunch
 
     def initialize
-      @cli_options = {}
       @config_loader = Vcloud::ConfigLoader.new
     end
 
     def run(config_file = nil, options = {})
-      @cli_options = options
-
-      puts "cli_options: #{@cli_options}" if @cli_options[:debug]
-
       config = @config_loader.load_config(config_file)
 
-      if @cli_options[:mock] || ENV['FOG_MOCK']
+      if options[:mock] || ENV['FOG_MOCK']
         ::Fog.mock!
       end
 


### PR DESCRIPTION
implementing feedback received from Nick on my story.

Current cli options require too much typing. e.g—dont-power-on,—continue-on-error,—debug,—verbose.
added shortcuts for these options.

I will raise a separate pull request to fix cli options for query(they are too many).

Question: 

CLI options verbose and debug don't do much, i am wondering if we need them.
Debug should ideally give me , debug info of each interaction with fog. 
