### PR TITLE
running all integration tests on ci

### DIFF
--- a/jenkins_integration_tests.sh
+++ b/jenkins_integration_tests.sh
@@ -6,6 +6,6 @@ bundle install --path "${HOME}/bundles/${JOB_NAME}"
 
 export FOG_RC=fog_integration_test.config
 
-bundle exec rake integration_test
+bundle exec rake integration:all
 
 rm fog_integration_test.config


### PR DESCRIPTION
After this change, storage_profile and org_vdc_network integration tests will fail, due to lack of set-up on ci.

I would let them fail and fix them tomorrow.
