### PR TITLE
[#62380500] changed source/destination_ip type to ip_Address

### DIFF
--- a/lib/vcloud/schema/edge_gateway.rb
+++ b/lib/vcloud/schema/edge_gateway.rb
@@ -4,12 +4,13 @@ module Vcloud
     FIREWALL_RULE = {
         type: Hash,
         internals: {
+            id: { type: 'string_or_number', required: false},
             enabled: { type: 'boolean', required: false},
             match_on_translate: { type: 'boolean', required: false},
             description: { type: 'string', required: false, allowed_empty: true},
             policy: { type: 'enum', required: false, acceptable_values: ['allow', 'drop'] },
-            source_ip: { type: 'string', required: true },
-            destination_ip: { type: 'string', required: true },
+            source_ip: { type: 'ip_address', required: true },
+            destination_ip: { type: 'ip_address', required: true },
             source_port_range: { type: 'string', required: false },
             destination_port_range: { type: 'string', required: false },
             enable_logging: { type: 'boolean', required: false },

--- a/spec/vcloud/edge_gateway/firewall_schema_validation_spec.rb
+++ b/spec/vcloud/edge_gateway/firewall_schema_validation_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+module Vcloud
+  describe 'firewall_service_schema_validations' do
+    context 'source and destination ips' do
+      it 'should error if source_ip/destination_ip are invalid IPs' do
+        config = {
+          firewall_rules: [
+            {
+              id: '999',
+              description: "A rule",
+              destination_port_range: "22",
+              destination_ip: "10.10",
+              source_ip: "192.0",
+            }
+          ]
+
+        }
+        validator = ConfigValidator.validate(:base, config, Schema::FIREWALL_SERVICE)
+        expect(validator.valid?).to be_false
+        expect(validator.errors).to eq([
+                                         "source_ip: 192.0 is not a valid ip_address",
+                                         "destination_ip: 10.10 is not a valid ip_address"
+                                       ])
+      end
+
+      it 'should validate OK if source_ip/destination_ip are valid IPs' do
+        config = {
+          firewall_rules: [
+            {
+              id: '999',
+              description: "A rule",
+              destination_port_range: "22",
+              destination_ip: "10.10.10.20",
+              source_ip: "192.0.2.2",
+            }
+          ]
+
+        }
+        validator = ConfigValidator.validate(:base, config, Schema::FIREWALL_SERVICE)
+        expect(validator.valid?).to be_true
+      end
+    end
+  end
+end


### PR DESCRIPTION
fixing firewall_service schema. 
- The source and destination ip should be
  of type ip_address, and not string. Added tests for same.
- Added 'id' to schema. this was not captured in
  integration_tests, because we auto-gnerate ids when missing.
  It causes problem when we pass id explicitly.

cc @mikepea 
