### PR TITLE
[#64583754] (first cut) IP range validations

### DIFF
--- a/lib/vcloud/config_validator.rb
+++ b/lib/vcloud/config_validator.rb
@@ -5,7 +5,7 @@ module Vcloud
 
     attr_reader :key, :data, :schema, :type, :errors
 
-    VALID_ALPHABETICAL_VALUES_FOR_IP_RANGE = %w(any external internal)
+    VALID_ALPHABETICAL_VALUES_FOR_IP_RANGE = %w(Any external internal)
 
     def initialize(key, data, schema)
       raise "Nil schema" unless schema
@@ -58,11 +58,11 @@ module Vcloud
 
     def validate_ip_address_range
       unless data.is_a?(String)
-        @errors << "#{key}: #{@data} is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'any','internal' and 'external'."
+        @errors << "#{key}: #{@data} is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'Any','internal' and 'external'."
         return
       end
       valid = valid_cidr_or_ip_address? || valid_alphabetical_ip_range? || valid_ip_range?
-      @errors << "#{key}: #{@data} is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'any','internal' and 'external'." unless valid
+      @errors << "#{key}: #{@data} is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'Any','internal' and 'external'." unless valid
     end
 
     def valid_cidr_or_ip_address?

--- a/spec/vcloud/config_validator_spec.rb
+++ b/spec/vcloud/config_validator_spec.rb
@@ -436,7 +436,7 @@ module Vcloud
           schema = { type: 'ip_address_range' }
           v = ConfigValidator.validate(:base, data, schema)
           expect(v.valid?).to be_false
-          expect(v.errors).to eq(["base: 192.168.100.100/33 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'any','internal' and 'external'."])
+          expect(v.errors).to eq(["base: 192.168.100.100/33 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'Any','internal' and 'external'."])
         end
 
         it "should return error if network bit value is less than 0" do
@@ -444,7 +444,7 @@ module Vcloud
           schema = { type: 'ip_address_range' }
           v = ConfigValidator.validate(:base, data, schema)
           expect(v.valid?).to be_false
-          expect(v.errors).to eq(["base: 192.168.100.100/33 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'any','internal' and 'external'."])
+          expect(v.errors).to eq(["base: 192.168.100.100/33 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'Any','internal' and 'external'."])
         end
 
         it "should return error if network IP address is incorrect" do
@@ -452,12 +452,12 @@ module Vcloud
           schema = { type: 'ip_address_range' }
           v = ConfigValidator.validate(:base, data, schema)
           expect(v.valid?).to be_false
-          expect(v.errors).to eq(["base: 192.168.100./33 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'any','internal' and 'external'."])
+          expect(v.errors).to eq(["base: 192.168.100./33 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'Any','internal' and 'external'."])
         end
       end
 
       context "validate alphabetical values for IP range" do
-        %w(any internal external).each do |data|
+        %w(Any internal external).each do |data|
           it "should validate OK if IP range is '#{data}'" do
             schema = { type: 'ip_address_range' }
             v = ConfigValidator.validate(:base, data, schema)
@@ -471,7 +471,7 @@ module Vcloud
           schema = { type: 'ip_address_range' }
           v = ConfigValidator.validate(:base, data, schema)
           expect(v.valid?).to be_false
-          expect(v.errors).to eq(["base: invalid_ip_range_string is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'any','internal' and 'external'."])
+          expect(v.errors).to eq(["base: invalid_ip_range_string is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'Any','internal' and 'external'."])
         end
       end
 
@@ -489,7 +489,7 @@ module Vcloud
           schema = { type: 'ip_address_range' }
           v = ConfigValidator.validate(:base, data, schema)
           expect(v.valid?).to be_false
-          expect(v.errors).to eq(["base: 192.168.100-192.168.100.110 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'any','internal' and 'external'."])
+          expect(v.errors).to eq(["base: 192.168.100-192.168.100.110 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'Any','internal' and 'external'."])
         end
 
         it "should error if end IP address is incorrect" do
@@ -497,7 +497,7 @@ module Vcloud
           schema = { type: 'ip_address_range' }
           v = ConfigValidator.validate(:base, data, schema)
           expect(v.valid?).to be_false
-          expect(v.errors).to eq(["base: 192.168.100.110-192.168.100 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'any','internal' and 'external'."])
+          expect(v.errors).to eq(["base: 192.168.100.110-192.168.100 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'Any','internal' and 'external'."])
         end
 
         it "should error if the combination of start IP and end IP is incorrect" do
@@ -505,7 +505,7 @@ module Vcloud
           schema = { type: 'ip_address_range' }
           v = ConfigValidator.validate(:base, data, schema)
           expect(v.valid?).to be_false
-          expect(v.errors).to eq(["base: 200.168.100.99-192.168.100 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'any','internal' and 'external'."])
+          expect(v.errors).to eq(["base: 200.168.100.99-192.168.100 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'Any','internal' and 'external'."])
         end
 
         it "should error if the start and end IPS are not separated by -" do
@@ -513,7 +513,7 @@ module Vcloud
           schema = { type: 'ip_address_range' }
           v = ConfigValidator.validate(:base, data, schema)
           expect(v.valid?).to be_false
-          expect(v.errors).to eq(["base: 190.168.100.99:192.168.100 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'any','internal' and 'external'."])
+          expect(v.errors).to eq(["base: 190.168.100.99:192.168.100 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'Any','internal' and 'external'."])
         end
       end
 


### PR DESCRIPTION
- Fixed the existing 'ip_address' validation. It used to look for only
  first four octets.It used to accept IPs like 192.168.100.100/33/33 ,
  192.168.100.100/33 etc. Added more strict validation using regex.
- Added a new schema element type 'ip_address_range'. The valid values for
  this type are -
- singleIP address
- CIDR
- valid IP range separated by '-'.
- alphabetical values like 'any','internal' and 'external'.
  Added validations for above acceptable values.
