### PR TITLE
VCLOUD_NO_RESET_VSE_AFTER test behaviour switch

### DIFF
--- a/spec/integration/edge_gateway/edge_gateway_services_spec.rb
+++ b/spec/integration/edge_gateway/edge_gateway_services_spec.rb
@@ -210,7 +210,7 @@ module Vcloud
       end
 
       after(:all) do
-        reset_edge_gateway
+        reset_edge_gateway unless ENV['VCLOUD_NO_RESET_VSE_AFTER']
       end
 
     end


### PR DESCRIPTION
so that we can speed up repeated VSE integration test runs
