### PR TITLE
[#62380500] Refactor of update method

### DIFF
--- a/lib/vcloud/edge_gateway_services.rb
+++ b/lib/vcloud/edge_gateway_services.rb
@@ -17,31 +17,30 @@ module Vcloud
 
     def update(config_file = nil, options = {})
       config = @config_loader.load_config(config_file, Vcloud::Schema::EDGE_GATEWAY_SERVICES)
-      nat_service_config = EdgeGateway::ConfigurationGenerator::NatService.new(config[:gateway], config[:nat_service]).generate_fog_config
-      firewall_service_config = EdgeGateway::ConfigurationGenerator::FirewallService.new.generate_fog_config(config[:firewall_service])
-
       local_config = { gateway: config[:gateway] }
-      local_config[:FirewallService] = firewall_service_config unless firewall_service_config.nil?
-      local_config[:NatService] = nat_service_config unless nat_service_config.nil?
 
       edge_gateway = Core::EdgeGateway.get_by_name local_config[:gateway]
       remote_config = edge_gateway.vcloud_attributes[:Configuration][:EdgeGatewayServiceConfiguration]
-      diff_output = {}
 
-      skipped_service_count = 0
-      EdgeGatewayServices.edge_gateway_services.each do |service|
-        local = local_config[service]
-        remote = remote_config[service]
-        differ = EdgeGateway::ConfigurationDiffer.new(local, remote)
-        diff_output[service] = differ.diff
+      firewall_service_config = EdgeGateway::ConfigurationGenerator::FirewallService.new.generate_fog_config(config[:firewall_service])
 
-        if diff_output[service].empty? or not local_config.key?(service)
-          skipped_service_count += 1
-          local_config.delete(service)
+      unless firewall_service_config.nil?
+        differ = EdgeGateway::ConfigurationDiffer.new(firewall_service_config, remote_config[:FirewallService])
+        unless differ.diff.empty?
+          local_config[:FirewallService] = firewall_service_config
         end
       end
 
-      if skipped_service_count == EdgeGatewayServices.edge_gateway_services.size
+      nat_service_config = EdgeGateway::ConfigurationGenerator::NatService.new(config[:gateway], config[:nat_service]).generate_fog_config
+
+      unless nat_service_config.nil?
+        differ = EdgeGateway::ConfigurationDiffer.new(nat_service_config, remote_config[:NatService])
+        unless differ.diff.empty?
+          local_config[:NatService] = nat_service_config unless nat_service_config.nil?
+        end
+      end
+
+      if local_config[:FirewallService].nil? and local_config[:NatService].nil?
         Vcloud.logger.info("EdgeGatewayServices.update: Configuration is already up to date. Skipping.")
       else
         edge_gateway.update_configuration local_config


### PR DESCRIPTION
- Don't add the configuration to what you are sending if there's no difference, rather than adding it and then deleting it
- No need for count or iterating through EdgeGatewayServices

This is not the final version of this method. We need to dependency inject so that it can be tested and split it out so it doesn't have too many responsibilities, but this is as far as we are going with it for this story.

Note - the `self.edge_gateway_services` method is now no longer required but removing this will conflict with work Mike is doing on a different branch so I will remove it later.
