### PR TITLE
[#65429452] Split FirewallService schema into own file

### DIFF
--- a/lib/vcloud.rb
+++ b/lib/vcloud.rb
@@ -20,6 +20,7 @@ require 'vcloud/vapp_orchestrator'
 
 require 'vcloud/edge_gateway_services'
 require 'vcloud/schema/nat_service'
+require 'vcloud/schema/firewall_service'
 require 'vcloud/schema/load_balancer_service'
 require 'vcloud/schema/edge_gateway'
 require 'vcloud/edge_gateway/configuration_generator/id_ranges'

--- a/lib/vcloud/schema/edge_gateway.rb
+++ b/lib/vcloud/schema/edge_gateway.rb
@@ -1,40 +1,6 @@
 module Vcloud
   module Schema
 
-    FIREWALL_RULE = {
-        type: Hash,
-        internals: {
-            id: { type: 'string_or_number', required: false},
-            enabled: { type: 'boolean', required: false},
-            match_on_translate: { type: 'boolean', required: false},
-            description: { type: 'string', required: false, allowed_empty: true},
-            policy: { type: 'enum', required: false, acceptable_values: ['allow', 'drop'] },
-            source_ip: { type: 'ip_address_range', required: true },
-            destination_ip: { type: 'ip_address_range', required: true },
-            source_port_range: { type: 'string', required: false },
-            destination_port_range: { type: 'string', required: false },
-            enable_logging: { type: 'boolean', required: false },
-            protocols: { type: 'enum', required: false, acceptable_values: ['tcp', 'udp', 'icmp', 'tcp+udp', 'any']},
-        }
-    }
-
-    FIREWALL_SERVICE = {
-        type: Hash,
-        allowed_empty: true,
-        required: false,
-        internals: {
-            enabled: { type: 'boolean', required: false},
-            policy: { type: 'enum', required: false, acceptable_values: ['allow', 'drop'] },
-            log_default_action: { type: 'boolean', required: false},
-            firewall_rules: {
-                type: Array,
-                required: false,
-                allowed_empty: true,
-                each_element_is: FIREWALL_RULE
-            }
-        }
-    }
-
     EDGE_GATEWAY_SERVICES = {
         type: 'hash',
         allowed_empty: false,

--- a/lib/vcloud/schema/firewall_service.rb
+++ b/lib/vcloud/schema/firewall_service.rb
@@ -1,0 +1,39 @@
+module Vcloud
+  module Schema
+
+    FIREWALL_RULE = {
+        type: Hash,
+        internals: {
+            id: { type: 'string_or_number', required: false},
+            enabled: { type: 'boolean', required: false},
+            match_on_translate: { type: 'boolean', required: false},
+            description: { type: 'string', required: false, allowed_empty: true},
+            policy: { type: 'enum', required: false, acceptable_values: ['allow', 'drop'] },
+            source_ip: { type: 'ip_address_range', required: true },
+            destination_ip: { type: 'ip_address_range', required: true },
+            source_port_range: { type: 'string', required: false },
+            destination_port_range: { type: 'string', required: false },
+            enable_logging: { type: 'boolean', required: false },
+            protocols: { type: 'enum', required: false, acceptable_values: ['tcp', 'udp', 'icmp', 'tcp+udp', 'any']},
+        }
+    }
+
+    FIREWALL_SERVICE = {
+        type: Hash,
+        allowed_empty: true,
+        required: false,
+        internals: {
+            enabled: { type: 'boolean', required: false},
+            policy: { type: 'enum', required: false, acceptable_values: ['allow', 'drop'] },
+            log_default_action: { type: 'boolean', required: false},
+            firewall_rules: {
+                type: Array,
+                required: false,
+                allowed_empty: true,
+                each_element_is: FIREWALL_RULE
+            }
+        }
+    }
+
+  end
+end


### PR DESCRIPTION
The FirewallService schema definition constants were located
with the top level EdgeGateway definitions historically. This
commit makes it more like the other services (Nat, LoadBalancer)
