### PR TITLE
[#63542018] Basic integration test for net launcher

### DIFF
--- a/spec/integration/net_launcher/data/minimum_data_setup.yaml.erb
+++ b/spec/integration/net_launcher/data/minimum_data_setup.yaml.erb
@@ -1,0 +1,9 @@
+---
+org_vdc_networks:
+
+- name: <%= network_name %>
+  vdc_name: <%= vdc_name %>
+  fence_mode: <%= fence_mode %>
+  netmask: <%= netmask %>
+  gateway: <%= gateway %>
+  edge_gateway: <%= edgeGateway %>

--- a/spec/integration/net_launcher/vcloud_net_launcher_spec.rb
+++ b/spec/integration/net_launcher/vcloud_net_launcher_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+require 'pp'
+require 'erb'
+
+describe Vcloud::NetLaunch do
+
+  context 'with minimum input setup' do
+
+    it 'should create an isolated network' do
+      test_data = default_test_data('isolated')
+      @minimum_data_yaml = generate_data_file(test_data)
+
+      Vcloud::NetLaunch.new.run(@minimum_data_yaml)
+
+      @found_networks = find_network(test_data[:network_name])
+      @found_networks.length.should == 1
+      provisioned_network = @found_networks[0]
+      provisioned_network[:gateway].should == test_data[:gateway]
+      provisioned_network[:netmask].should == test_data[:netmask]
+      provisioned_network[:isLinked].should == 'false'
+    end
+
+    it 'should create an nat routed network' do
+      test_data = default_test_data('natRouted')
+      test_data[:edgeGateway] =  ENV['VCLOUD_EDGE_GATEWAY']  #only needed for natRouted networks
+      @minimum_data_yaml = generate_data_file(test_data)
+
+      Vcloud::NetLaunch.new.run(@minimum_data_yaml)
+
+      @found_networks = find_network(test_data[:network_name])
+
+      @found_networks.length.should == 1
+      provisioned_network = @found_networks[0]
+      provisioned_network[:gateway].should == test_data[:gateway]
+      provisioned_network[:netmask].should == test_data[:netmask]
+      provisioned_network[:isLinked].should == 'true'
+    end
+
+    after(:each) do
+      unless ENV['VCLOUD_TOOLS_RSPEC_NO_DELETE_VAPP']
+        File.delete @minimum_data_yaml
+        fog_interface = Vcloud::Fog::ServiceInterface.new
+        provisioned_network_id = @found_networks[0][:href].split('/').last
+        fog_interface.delete_network(provisioned_network_id).should == true
+      end
+    end
+
+  end
+
+  def default_test_data(type)
+    {
+      network_name: "vapp-vcloud-tools-tests-#{Time.now.strftime('%s')}",
+      vdc_name: ENV['VCLOUD_VDC_NAME'],
+      fence_mode: type,
+      netmask: '255.255.255.0',
+      gateway: '192.0.2.1',
+    }
+  end
+
+  def find_network(network_name)
+    query = Vcloud::Query.new('orgNetwork', :filter => "name==#{network_name}")
+    query.get_all_results
+  end
+
+  def generate_data_file(test_data)
+    minimum_data_erb = File.join(File.dirname(__FILE__), 'data/minimum_data_setup.yaml.erb')
+    ErbHelper.convert_erb_template_to_yaml(test_data, minimum_data_erb)
+  end
+
+end


### PR DESCRIPTION
Tests to ensure that the basic operation of the Net Launcher continue to work. 

These use the VCloud Query code to get the result of the launcher as finding a network by name isn't an available option in the API. 
