### PR TITLE
[#63542018] Exclude net-launch integration tests from quick test run

### DIFF
--- a/spec/integration/net_launcher/vcloud_net_launcher_spec.rb
+++ b/spec/integration/net_launcher/vcloud_net_launcher_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'pp'
 require 'erb'
 
-describe Vcloud::NetLaunch do
+describe Vcloud::NetLaunch, :take_too_long => true do
 
   context 'with minimum input setup' do
 


### PR DESCRIPTION
These tests run to about 6+ mins so we want to exclude them from the quick feedback run. 

As requested by @annashipman 
