### PR TITLE
Run against latest vcloud-core

### DIFF
--- a/vcloud-tools.gemspec
+++ b/vcloud-tools.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'bundler'
   s.add_runtime_dependency 'methadone'
-  s.add_runtime_dependency 'vcloud-core'
+  s.add_runtime_dependency 'vcloud-core', '>= 0.0.7'
   s.add_runtime_dependency 'hashdiff'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.14.1'


### PR DESCRIPTION
0.0.7 needed to fix bug with vAppTemplate name lookup
