### PR TITLE
[#65625634] Update Net Launch to use core config

### DIFF
--- a/lib/vcloud/net_launch.rb
+++ b/lib/vcloud/net_launch.rb
@@ -5,7 +5,7 @@ module Vcloud
   class NetLaunch
 
     def initialize
-      @config_loader = Vcloud::ConfigLoader.new
+      @config_loader = Vcloud::Core::ConfigLoader.new
     end
 
     def run(config_file = nil, options = {})


### PR DESCRIPTION
I meant to do this and forgot, and this was only picked up in the long version of the integration tests. Meaning that there are no unit tests around this at all. We should fix that.

This, in the meantime, will fix the failing integration test. There are no other instances of ConfigLoader to change in vcloud-tools.
