### PR TITLE
Add a vcloud-identify-vm utility

### DIFF
--- a/utils/vcloud-identify-vm
+++ b/utils/vcloud-identify-vm
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+
+require 'rubygems'
+require 'bundler/setup'
+require 'optparse'
+require 'methadone'
+
+require 'vcloud'
+
+class App
+
+  include Methadone::Main
+  include Methadone::CLILogging
+  include Vcloud
+
+  main do |vm|
+    require 'pp'
+
+    puts "Getting VDC Information...."
+
+    all_vdcs = Query.new("orgVdc", {}).get_all_results
+
+    puts "Getting VM Information..."
+    all_vms = Query.new("vm", {}).get_all_results
+
+    found = all_vms.select{|v| v[:containerName] =~ /#{vm}/ || v[:name] =~ /#{vm}/ }
+
+    abort("Could not find any VMs matching /%s/" % vm) if found.empty?
+
+    puts
+
+    found.each do |machine|
+      vdc = all_vdcs.select{|v| v[:href] == machine[:vdc]}.first
+
+      puts "Container Name: %s" % machine[:containerName]
+      puts "          Name: %s (%s)" % [machine[:name], machine[:href].split("/").last]
+      puts "       Orgname: %s" % vdc[:orgName]
+      puts "           VDC: %s (%s)" % [vdc[:name], vdc[:href].split("/").last]
+      puts
+    end
+  end
+
+  arg :vm
+
+  description 'Identifies a VM in a way that a vCloud provider can reliably find
+  it rather than get confused with similarly named VMs across Orgs
+
+  It takes a single argument that gets regex matched across container name and
+  vm name.
+
+  See https://github.com/alphagov/vcloud-tools for more info'
+
+  version Vcloud::VERSION
+
+  use_log_level_option
+
+  go!
+end
+


### PR DESCRIPTION
vcloud providers seem to have a problem identifying virtual machines by
name, they prefer VM UUIDs and Org IDs.

This helper will search across all container names and vm names and show
all matching ones in a way that providers can use to uniquely identify a
VM even in the case where there are many similarly named ones.
