### PR TITLE
Requires Core v0.0.10 for QueryRunner

### DIFF
--- a/vcloud-tools.gemspec
+++ b/vcloud-tools.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'bundler'
   s.add_runtime_dependency 'methadone'
-  s.add_runtime_dependency 'vcloud-core', '>= 0.0.9'
+  s.add_runtime_dependency 'vcloud-core', '>= 0.0.10'
   s.add_runtime_dependency 'hashdiff'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.14.1'


### PR DESCRIPTION
In https://github.com/alphagov/vcloud-tools/pull/172 I changed the way we used the Query api interface, but did not bump the version, this causes the tool to fail if a previous version of Vcloud-core has been installed.

I'm assuming we don't need to bump the version of this tool as the behaviour remains the same. Please correct if that assumption is wrong
