### PR TITLE
Update for recent changer to launcher related files

### DIFF
--- a/lib/vcloud.rb
+++ b/lib/vcloud.rb
@@ -11,9 +11,7 @@ require 'vcloud/version'
 require 'vcloud/fog'
 require 'vcloud/core'
 
-require 'vcloud/launch'
-require 'vcloud/vm_orchestrator'
-require 'vcloud/vapp_orchestrator'
+require 'vcloud/launcher'
 
 module Vcloud
 

--- a/vcloud-tools.gemspec
+++ b/vcloud-tools.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'bundler'
   s.add_runtime_dependency 'methadone'
   s.add_runtime_dependency 'vcloud-core', '>= 0.0.11'
+  s.add_runtime_dependency 'vcloud-launcher', '~> 0.0.2'
   s.add_runtime_dependency 'hashdiff'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.14.1'


### PR DESCRIPTION
In the past the vcloud-tools included vcloud/launch.rb and a few other
files.  These recently moved to their own gem vcloud-launcher.

Since that change though this repo needs to be updated to include the
dependency and to account for some changes from vcloud/launch to
vcloud/launcher etc.  This commit does that.
