### PR TITLE
Fix broken links in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A tool that takes a YAML configuration file describing vCloud networks and confi
 ## [vCloud Walker][vcloud-walker]
 A gem that reports on the current state of an environment
 
-## [vCloud Query][vcloud-query]
+## [vCloud Query](https://github.com/alphagov/vcloud-core/blob/master/README.md#vcloud-query)
 A tool to expose the vCloud Query API, bundled with the [vCloud Core gem][vcloud-core]
 
 ## [vCloud Edge Gateway][vcloud-edgegateway]


### PR DESCRIPTION
Fix a broken link to the vCloud Query documentation and remove the link to the 'utils' scripts which have been removed.
