### PR TITLE
[Fixes #70438882] Don't specify gem versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.9.0 (2014-05-19)
+
+Features:
+
+  - We no longer specify a version for the gems that this meta-gem installs;
+    installing this gem should now install the most recent versions of its dependencies.
+
 ## 0.8.0 (2014-04-23)
 
 Features:

--- a/lib/vcloud/tools/version.rb
+++ b/lib/vcloud/tools/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module Tools
-    VERSION = '0.8.0'
+    VERSION = '0.9.0'
   end
 end

--- a/vcloud-tools.gemspec
+++ b/vcloud-tools.gemspec
@@ -17,11 +17,11 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'vcloud-core', '>= 0.0.12'
-  s.add_runtime_dependency 'vcloud-edge_gateway', '>= 0.2.3'
-  s.add_runtime_dependency 'vcloud-launcher', '>= 0.0.3'
-  s.add_runtime_dependency 'vcloud-net_launcher', '>=0.0.2'
-  s.add_runtime_dependency 'vcloud-walker', '>= 3.2.1'
+  s.add_runtime_dependency 'vcloud-core'
+  s.add_runtime_dependency 'vcloud-edge_gateway'
+  s.add_runtime_dependency 'vcloud-launcher'
+  s.add_runtime_dependency 'vcloud-net_launcher'
+  s.add_runtime_dependency 'vcloud-walker'
   s.add_development_dependency 'gem_publisher', '1.2.0'
   s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Don't specify the versions that this meta-gem installs.

By not specifying the versions, new users of vCloud Tools will install
the latest available versions of the tools and we avoid having to
increment the versions each time a gem is updated.

---

Also bump the version to 0.9.0 and update the CHANGELOG accordingly.
