### PR TITLE
Clean workspace before starting

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,4 +1,6 @@
 #!/bin/bash -x
 set -e
+
+git clean -ffdx
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 bundle exec rake publish_gem


### PR DESCRIPTION
I noticed the Jenkins job in CI has `rm -rf Gemfile.lock` as a command. It would be better to have this here as per the other gems.

I have removed the command from the Jenkins job in anticipation of this being merged...
