### PR TITLE
Speculative, for discussion: Add required Ruby version

### DIFF
--- a/vcloud-tools.gemspec
+++ b/vcloud-tools.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
+  s.required_ruby_version = '>= 1.9.3'
+
   s.add_runtime_dependency 'vcloud-core'
   s.add_runtime_dependency 'vcloud-edge_gateway'
   s.add_runtime_dependency 'vcloud-launcher'


### PR DESCRIPTION
While cleaning up environment variables in Jenkins I noticed that the vCloud Tools job injects the following environment variable: `RBENV_VERSION=1.9.3-p392`.

I've also noticed previously that our gems claim to work with any version of Ruby:

Ruby Dependency

```
>= 0
```

http://rubygems.org/gems/vcloud-tools.

I'm guessing this is not the case! So we should set that. Is it `1.9.3`? Does anyone want to test this or can we assume it? Should we add this to all the gems? Discuss.
