### PR TITLE
Use https://rubygems in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gemspec


### PR DESCRIPTION
This is best practice because it gives us _some_ integrity about who we are
downloading gems from.

Following gds-operations/vcloud-launcher#52
