### PR TITLE
Update credentials docs for vcloud-login

### DIFF
--- a/usage.md
+++ b/usage.md
@@ -37,7 +37,7 @@ The vCloud Tools projects are based around [fog](http://fog.io/). To use it you'
 
       eval $(FOG_CREDENTIAL=test_credentials vcloud-login)
 
-  This will prompt for your password and export an environment variable.
+  This will prompt for your password and export a `FOG_VCLOUD_TOKEN` environment variable.
 
 3. Specify your credentials at the beginning of the command. For example:
 


### PR DESCRIPTION
Extracted from vcloud-core's README. With the additional removal of the
password NB, now that core is issuing deprecation warnings. I'll then point
the READMEs of core and the other projects to this page instead of
duplicating the credentials documentation.
