### PR TITLE
Move integration testing instructions to website

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -4,6 +4,37 @@ title: Testing
 permalink: /testing/
 ---
 
+## Running integration tests
+
+All the vCloud Tools also have integration tests which run the code against a live environment, spinning up and destroying VMs etc. Please note that this means they take some time to run.
+
+### Prerequisites
+
+- Access to a suitable vCloud Director organisation.
+
+    *NB* It is not safe to run the integration tests against an environment that
+    is in use (e.g. production, preview) as many of the tests clear down all
+    config at the beginning and/or end to ensure the environment is as the tests
+    expect.
+
+- A config file with the settings configured.
+
+    Each of the tools has a template file in the `spec/integration` directory
+    called `vcloud_tools_testing_config.yaml.template`. This indicates the
+    parameters required to run the integration test for that tool. Copy the
+    template file to spec/integration/vcloud_tools_testing_config.yaml and
+    update with parameters suitable for your environment.
+
+- The set-up for your testing environment needs to be included in your fog file.
+
+- The tests use the vCloud Tools Tester gem. You do not need to install this, bundler will do this for you.
+
+### To run the tests
+
+````
+FOG_CREDENTIAL=test_credential bundle exec integration
+````
+
 ## Writing fog Mocks
 
 Ideally, all requests in [fog](https://github.com/fog/fog) would have Mocks, which would allow us to run our integration tests in Mock mode, taking seconds, rather than minutes. However, many of them do not. This is a quick guide as to how to write Mocks in fog.

--- a/testing.md
+++ b/testing.md
@@ -31,6 +31,8 @@ All the vCloud Tools also have integration tests which run the code against a li
 
 ### To run the tests
 
+To run the tests you need to log in in the same way as you would ordinarily. See [usage](/vcloud-tools/usage/) for more details. Once you have obtained a session token, you can run the integration tests:
+
 ````
 FOG_CREDENTIAL=test_credential bundle exec integration
 ````


### PR DESCRIPTION
While working on a firebreak story (briefly!) I noticed that the instructions for how to run integration tests on the tools have not been updated since the addition of `vcloud-login` and the need to get a session token. These instructions are duplicated in every tool and the only difference is the parameters required. In addition (based in part on the fact that the instructions hadn't been updated) I don't think people are running them locally very often, if at all.

I suggest we move the instructions onto the website to increase the likelihood of them staying up-to-date when changes are made. If this is merged, I will follow up with PRs on all the tools removing the instructions there and linking to these ones.