### PR TITLE
Add blog posts on About page

### DIFF
--- a/about.md
+++ b/about.md
@@ -1,0 +1,17 @@
+---
+layout: page
+title: About
+permalink: /about/
+---
+
+vCloud Tools has been developed by the [Government Digital Service](https://gds.blog.gov.uk/).
+
+We have written some blog posts about the tools:
+
+[Building tools to provision our machines](https://gdstechnology.blog.gov.uk/2014/05/07/building-tools-to-provision-our-machines/)
+
+[How we used vCloud Tools to provision a new platform](https://gdstechnology.blog.gov.uk/2014/05/21/using-vcloud-tools-to-provision-a-new-platform/)
+
+[Using Git to refactor vCloud Tools into separate gems](https://gdstechnology.blog.gov.uk/2014/06/04/using-git-to-refactor-vcloud-tools-into-separate-gems/)
+
+[How we moved vCloud Tools from Coding in the Open to Open Source](https://gdstechnology.blog.gov.uk/2014/12/19/how-we-moved-vcloud-tools-from-coding-in-the-open-to-open-source/)


### PR DESCRIPTION
We've written loads of great stuff about vCloud Tools and we'll probably write more; it would be good to includelinks to them on our website.

I added an About page rather than lengthening the index page because I think the index page is good as it is and this should just be available if people want more info.