### PR TITLE
Amend integration test command

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -34,7 +34,7 @@ All the vCloud Tools also have integration tests which run the code against a li
 To run the tests you need to log in in the same way as you would ordinarily. See [usage](/vcloud-tools/usage/) for more details. Once you have obtained a session token, you can run the integration tests:
 
 ````
-FOG_CREDENTIAL=test_credential bundle exec integration
+FOG_CREDENTIAL=test_credential bundle exec rake integration
 ````
 
 ## Writing fog Mocks


### PR DESCRIPTION
The command mentioned in the README to run the integration tests is wrong,
since `integration` is not a standalone Gem but rather defined in the
Rakefile. As such, it needs to be called through `rake`.

When running the command as-is, the only output is that `integration` could
not be found with a suggestion to install Gems from the Gemfile using
Bundler.

Updates the command to reflect this.