### PR TITLE
Bump vcloud-core version to 1.2.0

### DIFF
--- a/vcloud-tools.gemspec
+++ b/vcloud-tools.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'vcloud-core'
+  s.add_runtime_dependency 'vcloud-core', '~> 1.2.0'
   s.add_runtime_dependency 'vcloud-edge_gateway'
   s.add_runtime_dependency 'vcloud-launcher'
   s.add_runtime_dependency 'vcloud-net_launcher'


### PR DESCRIPTION
We need to pull in new cloud-core, which requires
a new fog version, which has functionality we need
in vcloud-edge-gateway.

gds-operations/vcloud-core#177