### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.0 (2017-06-24)
+
+  - Bring version number into line with the rest of the vCloud Tools estate
+  - Make Ruby 2.2.2 the lowest possible version of Ruby to use as per the rest
+    of the toolset.
+
 ## 1.0.0 (2014-05-19)
 
 Features:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ node {
 
     if (env.BRANCH_NAME == "master") {
       stage("Publish gem") {
-        sh('bundle exec rake publish_gem')
+        govuk.publishGem(repoName, env.BRANCH_NAME)
       }
     }
   } catch (e) {

--- a/lib/vcloud/tools/version.rb
+++ b/lib/vcloud/tools/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module Tools
-    VERSION = '1.0.0'
+    VERSION = '2.1.0'
   end
 end

--- a/vcloud-tools.gemspec
+++ b/vcloud-tools.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.2.2'
 
   s.add_runtime_dependency 'vcloud-core'
   s.add_runtime_dependency 'vcloud-edge_gateway'


### PR DESCRIPTION
Release a new version of vCloud Tools, which brings the release version into line with the rest of the toolset. The gem by default will all pull all the latest gems, but this makes clear it's only for Ruby v2.2.2 and over.

https://trello.com/c/0uDbDpkt/574-update-dependencies-on-vcloud-tools