### PR TITLE
Remove running tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,10 +19,6 @@ node {
       govuk.bundleGem()
     }
 
-    stage("Run tests") {
-      govuk.runTests()
-    }
-
     if (env.BRANCH_NAME == "master") {
       stage("Publish gem") {
         govuk.publishGem(repoName, env.BRANCH_NAME)


### PR DESCRIPTION
This repository is just used to bundle all the tools into a single Gem. Remove the tests that were added as a default, but still bundle to make sure that works as intended, and then publish the gem if it's on master.